### PR TITLE
displays the first 3 matching lines (with highlighting) when an episo…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
+        "cross-env": "^7.0.3",
         "eslint": "^9",
         "eslint-config-next": "15.3.1",
         "tailwindcss": "^4",
@@ -2865,6 +2866,25 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
       }
     },
     "node_modules/cross-spawn": {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",
+    "debug": "cross-env NODE_OPTIONS='inspect' next dev",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"
@@ -30,6 +31,7 @@
     "eslint": "^9",
     "eslint-config-next": "15.3.1",
     "tailwindcss": "^4",
-    "typescript": "^5"
+    "typescript": "^5",
+    "cross-env": "^7.0.3"
   }
 }

--- a/src/app/api/episodes/route.ts
+++ b/src/app/api/episodes/route.ts
@@ -154,11 +154,7 @@ function enhancedLocalSearch(
 
       if (exactPhrase && lowerContent.includes(lowerQuery)) {
         // Highlight exact phrase
-        const highlightedContent = generateHighlight(
-          content,
-          lowerContent,
-          lowerQuery
-        );
+        const highlightedContent = generateHighlightWithRegex(content, query);
         if (!enhancedEpisode.highlight) enhancedEpisode.highlight = {};
         enhancedEpisode.highlight[field] = [highlightedContent];
       } else if (!exactPhrase) {
@@ -196,8 +192,15 @@ function enhancedLocalSearch(
   };
 }
 
-// Helper function to generate highlighted content with HTML
-function generateHighlight(
+/**
+ * Helper function to generate highlighted content with HTML
+ * @param content
+ * @param lowerContent
+ * @param lowerQuery
+ *
+ * @deprecated
+ */
+function generateHighlight( // eslint-disable-line
   content: string,
   lowerContent: string,
   lowerQuery: string
@@ -212,6 +215,22 @@ function generateHighlight(
 
   // Use em tags for highlighting (similar to Elasticsearch)
   return `${before}<span class="script-match">${match}</span>${after}`;
+}
+
+/**
+ * alternative to `generateHighlight()` that uses regex instead of substring.
+ * replaces all instances of `query` in `content` with `<span class="script-match">${query}</span>`
+ * (case-insensitive)
+ *
+ * @param content
+ * @param query
+ */
+function generateHighlightWithRegex(content: string, query: string): string {
+  const queryAsRegex = new RegExp(query, "gi");
+  const highlightedContent = content.replace(queryAsRegex, match => {
+    return `<span class="script-match">${match}</span>`;
+  });
+  return highlightedContent;
 }
 
 // Helper function to highlight individual term

--- a/src/components/EpisodeList.tsx
+++ b/src/components/EpisodeList.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { Episode } from "@/utils/types";
-import { formatDate } from "@/utils/ui";
-import { useState } from "react";
+import {EpisodeWithHighlight} from "@/utils/types";
+import {formatDate} from "@/utils/ui";
+import {useState} from "react";
+import SearchResultPreview from "@/components/SearchResultPreview";
 
 interface EpisodeListProps {
-  results: (Episode & { highlight?: Record<string, string[]> })[];
+  results: EpisodeWithHighlight[];
   totalResults: number;
   isLoading: boolean;
   loadMore: () => void;
@@ -93,11 +94,16 @@ export default function EpisodeList({
               </a>
             </div>
 
-            {episode.highlight && Object.keys(episode.highlight).length > 0 && (
+            {/* show a minimal preview of the search result; hidden when a
+             user expands the search result */}
+            {episode.highlight && !visibleScripts[episode.id] &&
+              <SearchResultPreview episode={episode} />
+            }
+
+            {/* show the full episode result */}
+            {episode.highlight && Object.keys(episode.highlight).length > 0 && visibleScripts[episode.id] && (
               <div
-                className={`my-6 rounded text-sm transition-all duration-300 ${
-                  visibleScripts[episode.id] ? "block" : "hidden"
-                }`}
+                className="my-6 rounded text-sm transition-all duration-300 block"
               >
                 {Object.entries(episode.highlight).map(
                   ([field, highlights]) => (

--- a/src/components/SearchResultPreview.tsx
+++ b/src/components/SearchResultPreview.tsx
@@ -2,8 +2,8 @@ import {EpisodeWithHighlight} from "@/utils/types";
 import {useEffect, useState} from "react";
 
 const MAX_PREVIEW_LINES = 3;
-const PREV_CHARACTERS = 10;
-const POST_CHARACTERS = 13;
+const PREV_CHARACTERS = 30;
+const POST_CHARACTERS = 30;
 const HIGHLIGHT_TAG_START = `<span class="script-match">`;
 const HIGHLIGHT_TAG_END = "</span>";
 

--- a/src/components/SearchResultPreview.tsx
+++ b/src/components/SearchResultPreview.tsx
@@ -1,0 +1,48 @@
+import {EpisodeWithHighlight} from "@/utils/types";
+import {useEffect, useState} from "react";
+
+const MAX_PREVIEW_LINES = 3;
+const PREV_CHARACTERS = 10;
+const POST_CHARACTERS = 13;
+const HIGHLIGHT_TAG_START = `<span class="script-match">`;
+const HIGHLIGHT_TAG_END = "</span>";
+
+function parseMatchedChunk(matchedChunk: string): string {
+  const startIndexOfMatch = matchedChunk.indexOf(HIGHLIGHT_TAG_START);
+  const endIndexOfMatch = matchedChunk.indexOf(HIGHLIGHT_TAG_END);
+  const preIndex = Math.max(0, startIndexOfMatch - PREV_CHARACTERS);
+  const postIndex = Math.min(endIndexOfMatch + POST_CHARACTERS, matchedChunk.length);
+  const preEllipsis = preIndex > 0 ? "..." : "";
+  const postEllipsis = postIndex < matchedChunk.length ? "..." : "";
+  return preEllipsis + matchedChunk.substring(preIndex, postIndex) + postEllipsis;
+}
+
+/**
+ * displays a list of highlighted snippets, truncated at both ends. see
+ * @param episode
+ * @constructor
+ */
+export default function SearchResultPreview({episode}: { episode: EpisodeWithHighlight }) {
+  const [highlightedSnippets, setHighlightedSnippets] = useState<string[]>([]);
+
+  useEffect(() => {
+    if (episode.highlight?.script) {
+      const chunks = episode.highlight.script[0].split("<br />");
+      setHighlightedSnippets(
+        chunks.filter(chunk => chunk.includes(HIGHLIGHT_TAG_START))
+          .slice(0, MAX_PREVIEW_LINES)
+          .map(parseMatchedChunk)
+      );
+    }
+  }, [episode]);
+
+  return (
+    <div>
+      <ul>
+        {highlightedSnippets.map((snippet, idx) => (
+          <li key={idx} dangerouslySetInnerHTML={{ __html: snippet }} />
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -9,3 +9,5 @@ export interface Episode {
   alt_embed_src?: string;
   youtube_id?: string;
 }
+
+export type EpisodeWithHighlight = Episode & { highlight?: Record<string, string[]> | undefined};


### PR DESCRIPTION
displays the first 3 matching lines (with highlighting) when an episode search result is collapsed

- intended to close #3 
- test it out with the search phrase "the wolf"

### notes

- added the `cross-env` package to devDependencies for nicer server-side debugging with JetBrains products
- I added a function `generateHighlightWithRegex` for convenience and also because when `exactPhrase` is `true` (default), only the first match is highlighted. please lmk if this is intended behavior -- I can't tell where/how `exactPhrase` is modifiable in the UI other than in the URL field
- down the road it might be nice to store script text as a list of lines rather than a blob of text